### PR TITLE
Update removeEventListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ import { AppRegistry, Text, TouchableOpacity, View } from "react-native";
 import PushNotificationAndroid from 'react-native-push-android';
 
 export default class Example extends Component {
+  
+  _localNotificationEvent = null;
+  _notificationEvent = null;
+  _refreshTokenEvent = null;
 
   state = {
     token: null
@@ -169,23 +173,28 @@ export default class Example extends Component {
       this.setState({ token: token });
     });
     
-    PushNotificationAndroid.addEventListener('localNotification', (details) => {
+    this._localNotificationEvent = PushNotificationAndroid.addEventListener('localNotification', (details) => {
       console.log('localNotification => ', details);
     });
 
-    PushNotificationAndroid.addEventListener('notification', (details) => {
+    this._notificationEvent = PushNotificationAndroid.addEventListener('notification', (details) => {
       console.log('remoteNotification => ', details);
     });
 
-    PushNotificationAndroid.addEventListener('refreshToken', (token) => {
+    this._refreshTokenEvent = PushNotificationAndroid.addEventListener('refreshToken', (token) => {
       console.log('remoteRefreshToken => ', token);
     });
   }
 
   componentWillUnMount() {
-    PushNotificationAndroid.removeEventListener('localNotification');
-    PushNotificationAndroid.removeEventListener('notification');
-    PushNotificationAndroid.removeEventListener('refreshToken'); 
+    this._localNotificationEvent.remove();
+    this._notificationEvent.remove();
+    this._refreshTokenEvent.remove();
+
+    // You can remove all listener events
+    PushNotificationAndroid.removeAllListeners('localNotification');
+    PushNotificationAndroid.removeAllListeners('notification');
+    PushNotificationAndroid.removeAllListeners('refreshToken'); 
   }
 
   sendLocalNotificationNormal = () => {    

--- a/android/src/main/java/br/com/helderfarias/pushandroid/RNPushAndroidPackage.java
+++ b/android/src/main/java/br/com/helderfarias/pushandroid/RNPushAndroidPackage.java
@@ -17,7 +17,7 @@ public class RNPushAndroidPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNPushAndroidModule(reactContext));
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }

--- a/index.js
+++ b/index.js
@@ -61,17 +61,17 @@ const addEventListener = (event, callback) => {
 
 const removeEventListener = (event) => {
   if (event == 'localNotification') {
-      NativeAppEventEmitter.removeEventListener('FCMLocalNotificationReceived');
+      NativeAppEventEmitter.removeAllListeners('FCMLocalNotificationReceived');
       return;
   }
 
   if (event == 'notification') {
-      NativeAppEventEmitter.removeEventListener('FCMNotificationReceived');
+      NativeAppEventEmitter.removeAllListeners('FCMNotificationReceived');
       return;
   }
 
   if (event == 'refreshToken') {
-      NativeAppEventEmitter.removeEventListener('FCMTokenRefreshed');
+      NativeAppEventEmitter.removeAllListeners('FCMTokenRefreshed');
       return;
   }  
 }

--- a/index.js
+++ b/index.js
@@ -44,22 +44,19 @@ const notify = (details) => {
 
 const addEventListener = (event, callback) => {
   if (event == 'localNotification') {
-      NativeAppEventEmitter.addListener('FCMLocalNotificationReceived', callback);
-      return;
+      return NativeAppEventEmitter.addListener('FCMLocalNotificationReceived', callback);
   }
 
   if (event == 'notification') {
-      NativeAppEventEmitter.addListener('FCMNotificationReceived', callback);
-      return;
+      return NativeAppEventEmitter.addListener('FCMNotificationReceived', callback);
   }
 
   if (event == 'refreshToken') {
-      NativeAppEventEmitter.addListener('FCMTokenRefreshed', callback);
-      return;
+      return NativeAppEventEmitter.addListener('FCMTokenRefreshed', callback);
   }
 }
 
-const removeEventListener = (event) => {
+const removeAllListeners = (event) => {
   if (event == 'localNotification') {
       NativeAppEventEmitter.removeAllListeners('FCMLocalNotificationReceived');
       return;
@@ -82,7 +79,8 @@ export default {
   cancelLocalNotifications,
   getScheduledLocalNotifications,
   addEventListener,
-  removeEventListener,
+  removeEventListener: removeAllListeners,  //  Compatible
+  removeAllListeners,
   getInitialNotification,
   getToken,
   notify,


### PR DESCRIPTION
`NativeAppEventEmitter` does not have the ` removeEventListener` method.

Source code: [NativeAppEventEmitter.addListener](https://github.com/facebook/react-native/blob/6e650937fddf19cf5b6f1d5577e18c2ed5f64df2/Libraries/EventEmitter/RCTDeviceEventEmitter.js#L52)